### PR TITLE
filter species that are on minSite number of sites or more

### DIFF
--- a/R/formatData.R
+++ b/R/formatData.R
@@ -74,7 +74,7 @@ formatData <- function(inData,
   sp_site <- (acast(inData, species~siteID, value.var = "obs", function(x) max(x) > 0, fill = 0))
 
   sp_n_Site <- rowSums(sp_site)
-  sp2incl <- which(sp_n_Site > minSite)
+  sp2incl <- which(sp_n_Site >= minSite)
   nExcl <- length(sp_n_Site) - length(sp2incl)
   print(paste('Note:',nExcl,'species out of', length(sp_n_Site), 'have been excluded because they occur on', minSite, 'sites or fewer'))
   if(length(sp2incl) > 0) {

--- a/R/formatData.R
+++ b/R/formatData.R
@@ -76,7 +76,7 @@ formatData <- function(inData,
   sp_n_Site <- rowSums(sp_site)
   sp2incl <- which(sp_n_Site >= minSite)
   nExcl <- length(sp_n_Site) - length(sp2incl)
-  print(paste('Note:',nExcl,'species out of', length(sp_n_Site), 'have been excluded because they occur on', minSite, 'sites or fewer'))
+  print(paste('Note:',nExcl,'species out of', length(sp_n_Site), 'have been excluded because they occur on fewer than', minSite, "sites"))
   if(length(sp2incl) > 0) {
     print(paste('We proceed to modelling with', length(sp2incl), 'species'))
   } else {


### PR DESCRIPTION
Chiara identified a bug related to minSite. The function filters out all species found on minSite number of sites or less. We want to retain the species found on minSite and only filter out those found on less than minSite number of sites.
This pull request fixes this bug.